### PR TITLE
Fixed NullProcessor with correct class name alias

### DIFF
--- a/src/processors.ts
+++ b/src/processors.ts
@@ -471,7 +471,7 @@ export namespace processor {
      * Construct a Null EntryProcessor.
      */
     protected constructor () {
-      super(processorName('NullEntryProcessor'))
+      super('util.NullEntryProcessor')
     }
   }
 


### PR DESCRIPTION
Found this issue when implementing the same on Python where the test for this failed in Python because of incorrect class name alias.