### PR TITLE
Generate a larger random password when creating self-signed certifica…

### DIFF
--- a/bin/keys.sh
+++ b/bin/keys.sh
@@ -29,7 +29,7 @@ fi
 mkdir -p "${CERTS_DIR}"
 
 # Generate random passwords for each run
-CAPASS="${RANDOM}"
+CAPASS=$(uuidgen | sha256sum | cut -f 1 -d " ")
 
 echo Generate Guardians CA key:
 echo "${CAPASS}" | openssl genrsa -passout stdin -aes256 \


### PR DESCRIPTION
…tes to avoid:

Generate Guardians CA key:
11:30:33 Generating RSA private key, 4096 bit long modulus (2 primes) 11:30:33 .......................++++
11:30:33 ...............................................++++ 11:30:34 e is 65537 (0x010001)
11:30:34 139763271575360:error:28078065:UI routines:UI_set_result_ex:result too small:crypto/ui/ui_lib.c:905:You must type in 4 to 1023 characters 11:30:34 139763271575360:error:28078065:UI routines:UI_set_result_ex:result too small:crypto/ui/ui_lib.c:905:You must type in 4 to 1023 characters 11:30:34 139763271575360:error:0906906F:PEM routines:PEM_ASN1_write_bio:read key:crypto/pem/pem_lib.c:357: 11:30:34